### PR TITLE
Fall back to system default PKG_CONFIG_PATH if unset

### DIFF
--- a/pkg/pkg.go
+++ b/pkg/pkg.go
@@ -42,6 +42,9 @@ func NewConfig(pcPaths []string) (Config, error) {
 		cfg.pcPaths = pcPaths
 	} else {
 		pkgConfigPath := os.Getenv("PKG_CONFIG_PATH")
+		if pkgConfigPath == "" {
+			pkgConfigPath = getSystemPath()
+		}
 		for _, path := range strings.Split(pkgConfigPath, ":") {
 			path = strings.TrimSpace(path)
 			if len(path) > 0 {

--- a/pkg/system_path.go
+++ b/pkg/system_path.go
@@ -1,0 +1,14 @@
+package pkg
+
+import "os/exec"
+
+// getSystemPath returns the installed pkg-config's default PKG_CONFIG_PATH, if
+// it is available, otherwise it returns an empty string.
+func getSystemPath() string {
+	cmd := exec.Command("pkg-config", "--variable=pc_path", "pkg-config")
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	return string(out)
+}


### PR DESCRIPTION
I'm a user of c-for-go. Unfortunately it couldn't work by default unless
a sensible PKG_CONFIG_PATH is specified, and it isn't totally obvious
how to determine that.

Instead, if PKG_CONFIG_PATH is unset, try to invoke the system pkg-config
and ask what path to use. If it's unavailable, then we just fall back to
the old behaviour of just returning an error.

For reference, here's what pkg-config returns on my system:

$ pkg-config --variable=pc_path pkg-config
/usr/local/lib/x86_64-linux-gnu/pkgconfig:/usr/local/lib/pkgconfig:/usr/local/share/pkgconfig:/usr/lib/x86_64-linux-gnu/pkgconfig:/usr/lib/pkgconfig:/usr/share/pkgconfig